### PR TITLE
feat: add custom smooth scroll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7933,7 +7933,8 @@
     "core-js": {
       "version": "3.22.8",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.8.tgz",
-      "integrity": "sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA=="
+      "integrity": "sha512-UoGQ/cfzGYIuiq6Z7vWL1HfkE9U9IZ4Ub+0XSiJTCzvbZzgPA69oDF2f+lgJ6dFFLEdjW5O6svvoKzXX23xFkA==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.22.8",
@@ -15687,11 +15688,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -18027,11 +18023,6 @@
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "react-smooth-scrollbar": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/react-smooth-scrollbar/-/react-smooth-scrollbar-8.0.6.tgz",
-      "integrity": "sha512-yWiIC4L8DwfIRkLL+PdXq5rysEm6trxHzRk1Rx82bzuu2aWDcHhT+l1vXH/73Re/zHmGjBgrxts/wIrwC6yYJA=="
-    },
     "react-syntax-highlighter": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
@@ -19000,23 +18991,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        }
-      }
-    },
-    "smooth-scrollbar": {
-      "version": "8.7.4",
-      "resolved": "https://registry.npmjs.org/smooth-scrollbar/-/smooth-scrollbar-8.7.4.tgz",
-      "integrity": "sha512-BSqZJExXoGbl9FGA4ci33DNmlHFRvDxJk4Q8OXmYykRLa1Hzg2YiV5slVogMd1UsxzNf6m0nralT8GdanKWoYw==",
-      "requires": {
-        "core-js": "^3.6.4",
-        "lodash-es": "^4.17.21",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scroll-parallax": "^3.2.0",
-    "react-smooth-scrollbar": "^8.0.6",
-    "smooth-scrollbar": "^8.7.4",
     "styled-components": "^5.3.3"
   },
   "devDependencies": {

--- a/src/components/effect-scroll/effect-scroll.js
+++ b/src/components/effect-scroll/effect-scroll.js
@@ -1,0 +1,14 @@
+import React, { useEffect } from 'react'
+import smoothScroll from './smooth-scroll'
+
+const EffectScroll = props => {
+  const { children } = props
+
+  useEffect(() => {
+    smoothScroll(document, 25, 20)
+  }, [])
+
+  return <div style={{ width: '100%' }}>{children}</div>
+}
+
+export default EffectScroll

--- a/src/components/effect-scroll/effect-scroll.js
+++ b/src/components/effect-scroll/effect-scroll.js
@@ -5,7 +5,7 @@ const EffectScroll = props => {
   const { children } = props
 
   useEffect(() => {
-    smoothScroll(document, 25, 20)
+    smoothScroll(document, 20, 20)
   }, [])
 
   return <div style={{ width: '100%' }}>{children}</div>

--- a/src/components/effect-scroll/index.js
+++ b/src/components/effect-scroll/index.js
@@ -1,0 +1,1 @@
+export { default as EffectScroll } from './effect-scroll'

--- a/src/components/effect-scroll/smooth-scroll.js
+++ b/src/components/effect-scroll/smooth-scroll.js
@@ -15,35 +15,6 @@ const smoothScroll = (target, speed, smooth) => {
       ? document.documentElement
       : target // safari scroll
 
-  target.addEventListener('mousewheel', scrolled, { passive: false })
-
-  target.addEventListener('DOMMouseScroll', scrolled, { passive: false })
-
-  function scrolled(e) {
-    e.preventDefault() // disable default scrolling
-
-    let delta = normalizeWheelDelta(e)
-
-    pos += -delta * speed
-
-    pos = Math.max(0, Math.min(pos, target.scrollHeight - frame.clientHeight)) // limit scrolling
-
-    if (!moving) {
-      update()
-    }
-  }
-
-  function normalizeWheelDelta(e) {
-    if (e.detail) {
-      if (e.wheelDelta) {
-        return (e.wheelDelta / e.detail / 40) * (e.detail > 0 ? 1 : -1)
-      }
-      // Opera
-      return -e.detail / 3 // Firefox
-    }
-    return e.wheelDelta / 120 // IE,Safari,Chrome
-  }
-
   function update() {
     moving = true
 
@@ -71,6 +42,35 @@ const smoothScroll = (target, speed, smooth) => {
       }
     )
   })()
+
+  function normalizeWheelDelta(e) {
+    if (e.detail) {
+      if (e.wheelDelta) {
+        return (e.wheelDelta / e.detail / 40) * (e.detail > 0 ? 1 : -1)
+      }
+      // Opera
+      return -e.detail / 3 // Firefox
+    }
+    return e.wheelDelta / 120 // IE,Safari,Chrome
+  }
+
+  function scrolled(e) {
+    e.preventDefault() // disable default scrolling
+
+    let delta = normalizeWheelDelta(e)
+
+    pos += -delta * speed
+
+    pos = Math.max(0, Math.min(pos, target.scrollHeight - frame.clientHeight)) // limit scrolling
+
+    if (!moving) {
+      update()
+    }
+  }
+
+  target.addEventListener('mousewheel', scrolled, { passive: false })
+
+  target.addEventListener('DOMMouseScroll', scrolled, { passive: false })
 }
 
 export default smoothScroll

--- a/src/components/effect-scroll/smooth-scroll.js
+++ b/src/components/effect-scroll/smooth-scroll.js
@@ -1,0 +1,76 @@
+const smoothScroll = (target, speed, smooth) => {
+  if (target === document)
+    target =
+      document.scrollingElement ||
+      document.documentElement ||
+      document.body.parentNode ||
+      document.body // cross browser support for document scrolling
+
+  let moving = false
+
+  let pos = target.scrollTop
+
+  let frame =
+    target === document.body && document.documentElement
+      ? document.documentElement
+      : target // safari scroll
+
+  target.addEventListener('mousewheel', scrolled, { passive: false })
+
+  target.addEventListener('DOMMouseScroll', scrolled, { passive: false })
+
+  function scrolled(e) {
+    e.preventDefault() // disable default scrolling
+
+    let delta = normalizeWheelDelta(e)
+
+    pos += -delta * speed
+
+    pos = Math.max(0, Math.min(pos, target.scrollHeight - frame.clientHeight)) // limit scrolling
+
+    if (!moving) {
+      update()
+    }
+  }
+
+  function normalizeWheelDelta(e) {
+    if (e.detail) {
+      if (e.wheelDelta) {
+        return (e.wheelDelta / e.detail / 40) * (e.detail > 0 ? 1 : -1)
+      }
+      // Opera
+      return -e.detail / 3 // Firefox
+    }
+    return e.wheelDelta / 120 // IE,Safari,Chrome
+  }
+
+  function update() {
+    moving = true
+
+    let delta = (pos - target.scrollTop) / smooth
+
+    target.scrollTop += delta
+
+    if (Math.abs(delta) > 0.5) {
+      requestFrame(update)
+    } else {
+      moving = false
+    }
+  }
+
+  let requestFrame = (function () {
+    // requestAnimationFrame cross browser
+    return (
+      window.requestAnimationFrame ||
+      window.webkitRequestAnimationFrame ||
+      window.mozRequestAnimationFrame ||
+      window.oRequestAnimationFrame ||
+      window.msRequestAnimationFrame ||
+      function (func) {
+        window.setTimeout(func, 1000 / 50)
+      }
+    )
+  })()
+}
+
+export default smoothScroll

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,31 +1,12 @@
-import * as React from 'react'
 import { HomeView } from 'views'
 
-import Scrollbar from 'react-smooth-scrollbar'
+import { EffectScroll } from 'components/effect-scroll'
 
 const HomePage = () => {
-  const [value, setValue] = React.useState(false)
-
   return (
-    <Scrollbar
-      damping={0.01}
-      thumbMinSize={60}
-      renderByPixels={true}
-      continuousScrolling={true}
-      plugins={{
-        overscroll: {
-          damping: 0.2,
-          enabled: true,
-          maxOverscroll: 150,
-          effect: 'bounce',
-        },
-      }}
-      onScroll={() => setValue(!value)}
-    >
-      <div style={{ height: '100vh' }}>
-        <HomeView />
-      </div>
-    </Scrollbar>
+    <EffectScroll>
+      <HomeView />
+    </EffectScroll>
   )
 }
 

--- a/src/views/home/home.styles.js
+++ b/src/views/home/home.styles.js
@@ -3,8 +3,9 @@ import styled from 'styled-components'
 import theme from 'theme'
 
 const HomeContainer = styled.div({
-  display: 'flex',
   alignItems: 'center',
+  backgroundColor: theme.colors.black,
+  display: 'flex',
   flexDirection: 'column',
   maxWidth: '100vw',
   overflowX: 'hidden',


### PR DESCRIPTION
#### Problem statement ⚠️
`smooth-scrollbar` and `react-smooth-scrollbar` libraries had some problems with re-renders when trying to use it with `react-scroll-parallax`
...

#### Summary of changes ✍️

- [x] Uninstall `smooth-scrollbar` and `react-smooth-scrollbar`.
- [x] Create a custom component `EffectScroll` to apply smoothness and speed to the default scrollbar.

#### Steps to test 🍻

...
